### PR TITLE
fix #17: use gender-neutral phrases

### DIFF
--- a/app/src/main/java/com/github/weg_li_android/data/model/Report.kt
+++ b/app/src/main/java/com/github/weg_li_android/data/model/Report.kt
@@ -59,7 +59,7 @@ data class Report(
     }
 
     companion object {
-        const val greetings = """Sehr geehrte Damen und Herren,
+        const val greetings = """Sehr geehrte Menschen,
 
 hiermit zeige ich, mit der Bitte um Weiterverfolgung, folgende Verkehrsordnungswidrigkeit an:
 """

--- a/app/src/test/java/com/github/weg_li_android/data/model/ReportTest.kt
+++ b/app/src/test/java/com/github/weg_li_android/data/model/ReportTest.kt
@@ -28,7 +28,7 @@ class ReportTest {
         )
 
         val testEmail = """
-            Sehr geehrte Damen und Herren,
+            Sehr geehrte Menschen,
             
             hiermit zeige ich, mit der Bitte um Weiterverfolgung, folgende Verkehrsordnungswidrigkeit an:
             


### PR DESCRIPTION
PS: I used GitHub's web UI to rapidly draft this PR. I suggest to squash the commits when merging (also using [GitHub's web UI](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges)) and use an overall more meaningful commit messages (e.g., `fix #17: use gender-neutral phrases`).